### PR TITLE
Add class mapping referenced assemblies

### DIFF
--- a/src/NHibernate.ProxyGenerators/Default/DefaultProxyGenerator.cs
+++ b/src/NHibernate.ProxyGenerators/Default/DefaultProxyGenerator.cs
@@ -89,6 +89,12 @@ namespace NHibernate.ProxyGenerators.Default
 			foreach (var cls in nhibernateConfiguration.ClassMappings)
 			{
 				references.Add(cls.MappedClass.Assembly);
+				foreach (var mapReferenceAssemblyName in cls.MappedClass.Assembly.GetReferencedAssemblies())
+				{
+					var mapReferenceAssembly = Assembly.Load(mapReferenceAssemblyName);
+					references.Add(mapReferenceAssembly);
+				}
+
 			}
 
 			foreach (var assembly in references)


### PR DESCRIPTION
This is needed when the class mapping assembly requires referenced assemblies to compile.  This is especially true when using fluent nhibernate mappings.