### PR TITLE
Add support for fluent nhibernate mappings

### DIFF
--- a/src/NHibernate.ProxyGenerators.Console.Test/NHibernate.ProxyGenerators.Console.Test.csproj
+++ b/src/NHibernate.ProxyGenerators.Console.Test/NHibernate.ProxyGenerators.Console.Test.csproj
@@ -78,6 +78,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/NHibernate.ProxyGenerators.Console.Test/app.config
+++ b/src/NHibernate.ProxyGenerators.Console.Test/app.config
@@ -3,10 +3,6 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
       </dependentAssembly>

--- a/src/NHibernate.ProxyGenerators.Console/NHibernate.ProxyGenerators.Console.csproj
+++ b/src/NHibernate.ProxyGenerators.Console/NHibernate.ProxyGenerators.Console.csproj
@@ -55,6 +55,9 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="FluentNHibernate, Version=2.0.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\FluentNHibernate.2.0.3.0\lib\net40\FluentNHibernate.dll</HintPath>
+    </Reference>
     <Reference Include="Iesi.Collections">
       <HintPath>..\..\packages\Iesi.Collections.4.0.1.4000\lib\net40\Iesi.Collections.dll</HintPath>
     </Reference>
@@ -77,6 +80,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/NHibernate.ProxyGenerators.Console/app.config
+++ b/src/NHibernate.ProxyGenerators.Console/app.config
@@ -3,10 +3,6 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
       </dependentAssembly>

--- a/src/NHibernate.ProxyGenerators.Console/packages.config
+++ b/src/NHibernate.ProxyGenerators.Console/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="FluentNHibernate" version="2.0.3.0" targetFramework="net40-client" />
   <package id="Iesi.Collections" version="4.0.1.4000" targetFramework="net40-Client" />
   <package id="NHibernate" version="4.1.1.4000" targetFramework="net40-client" />
 </packages>

--- a/src/NHibernate.ProxyGenerators/Default/DefaultProxyGenerator.cs
+++ b/src/NHibernate.ProxyGenerators/Default/DefaultProxyGenerator.cs
@@ -111,6 +111,27 @@ namespace NHibernate.ProxyGenerators.Default
 				nhibernateConfiguration.AddAssembly(inputAssembly);
 			}
 
+			FluentNHibernate.Cfg.Fluently.Configure(nhibernateConfiguration)
+			.Mappings(cfg =>
+			{
+				foreach (var assembly in inputAssemblies)
+				{
+					var fluent = cfg.FluentMappings.AddFromAssembly(assembly);
+					if (options.FluentConventions != null)
+					{
+						foreach (var conventionName in options.FluentConventions)
+						{
+							var t = System.Type.GetType(conventionName);
+							var convention = (FluentNHibernate.Conventions.IConvention)Activator.CreateInstance(t);
+							fluent.Conventions.Add(convention);
+
+						}
+					}
+				}
+			}).BuildConfiguration();
+
+
+
 			return nhibernateConfiguration;
 		}
 

--- a/src/NHibernate.ProxyGenerators/NHibernate.ProxyGenerators.csproj
+++ b/src/NHibernate.ProxyGenerators/NHibernate.ProxyGenerators.csproj
@@ -55,6 +55,9 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="FluentNHibernate, Version=2.0.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\FluentNHibernate.2.0.3.0\lib\net40\FluentNHibernate.dll</HintPath>
+    </Reference>
     <Reference Include="Iesi.Collections">
       <HintPath>..\..\packages\Iesi.Collections.4.0.1.4000\lib\net40\Iesi.Collections.dll</HintPath>
     </Reference>
@@ -84,6 +87,7 @@
     <Compile Include="ProxyGeneratorOptions.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/NHibernate.ProxyGenerators/ProxyGeneratorOptions.cs
+++ b/src/NHibernate.ProxyGenerators/ProxyGeneratorOptions.cs
@@ -24,6 +24,9 @@ namespace NHibernate.ProxyGenerators
 		[Argument(ArgumentType.Required, HelpText = "Path to output assembly for generated proxies.  e.g. .\\OutputAssembly.dll", ShortName = "o")]
 		public string OutputAssemblyPath;
 
+		[Argument(ArgumentType.MultipleUnique, HelpText = "Full Type name for fluent conventions.  e.g. My.Fluent.Conventions, MyAssembly", ShortName = "c")]
+		public string[] FluentConventions;
+
 		public ProxyGeneratorOptions()
 		{
 		}

--- a/src/NHibernate.ProxyGenerators/app.config
+++ b/src/NHibernate.ProxyGenerators/app.config
@@ -3,10 +3,6 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.1.0.4000" newVersion="4.1.0.4000" />
       </dependentAssembly>

--- a/src/NHibernate.ProxyGenerators/packages.config
+++ b/src/NHibernate.ProxyGenerators/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="FluentNHibernate" version="2.0.3.0" targetFramework="net40-client" />
   <package id="Iesi.Collections" version="4.0.1.4000" targetFramework="net40-Client" />
   <package id="ILRepack.Lib" version="1.25.0" targetFramework="net40-Client" />
   <package id="NHibernate" version="4.1.1.4000" targetFramework="net40-client" />


### PR DESCRIPTION
Note that the app.config binding redirects are necessary as fluent nhibernate currently targets a (slightly) older version of NHibernate.  However, everything works as expected.